### PR TITLE
Mongodb item writer implementation

### DIFF
--- a/eva-accession-import-dbsnp2/pom.xml
+++ b/eva-accession-import-dbsnp2/pom.xml
@@ -18,6 +18,10 @@
             <artifactId>spring-boot-starter-batch</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-mongodb</artifactId>
+        </dependency>
+        <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
             <artifactId>eva-accession-core</artifactId>
         </dependency>

--- a/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/configuration/BeanNames.java
+++ b/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/configuration/BeanNames.java
@@ -21,6 +21,8 @@ public class BeanNames {
 
     public static final String DBSNP_JSON_VARIANT_PROCESSOR = "DBSNP_JSON_VARIANT_PROCESSOR";
 
+    public static final String DBSNP_JSON_VARIANT_WRITER = "DBSNP_JSON_VARIANT_WRITER";
+
     public static final String IMPORT_DBSNP_JSON_VARIANTS_STEP = "IMPORT_DBSNP_JSON_VARIANTS_STEP";
 
     public static final String IMPORT_DBSNP_JSON_VARIANTS_JOB = "IMPORT_DBSNP_JSON_VARIANTS_JOB";

--- a/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/configuration/ImportDbsnpJsonVariantsStepConfiguration.java
+++ b/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/configuration/ImportDbsnpJsonVariantsStepConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
 import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.file.FlatFileItemReader;
 import org.springframework.batch.repeat.policy.SimpleCompletionPolicy;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,8 +29,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.ac.ebi.eva.accession.core.persistence.DbsnpClusteredVariantEntity;
 
-import static uk.ac.ebi.eva.accession.dbsnp2.configuration.BeanNames.DBSNP_JSON_VARIANT_PROCESSOR;
 import static uk.ac.ebi.eva.accession.dbsnp2.configuration.BeanNames.DBSNP_JSON_VARIANT_READER;
+import static uk.ac.ebi.eva.accession.dbsnp2.configuration.BeanNames.DBSNP_JSON_VARIANT_PROCESSOR;
+import static uk.ac.ebi.eva.accession.dbsnp2.configuration.BeanNames.DBSNP_JSON_VARIANT_WRITER;
 import static uk.ac.ebi.eva.accession.dbsnp2.configuration.BeanNames.IMPORT_DBSNP_JSON_VARIANTS_STEP;
 
 /**
@@ -47,13 +49,18 @@ public class ImportDbsnpJsonVariantsStepConfiguration {
     @Qualifier(DBSNP_JSON_VARIANT_PROCESSOR)
     private ItemProcessor<JsonNode, DbsnpClusteredVariantEntity> variantProcessor;
 
+    @Autowired
+    @Qualifier(DBSNP_JSON_VARIANT_WRITER)
+    private ItemWriter<DbsnpClusteredVariantEntity> variantWriter;
+
     @Bean(IMPORT_DBSNP_JSON_VARIANTS_STEP)
     public Step importDbsnpJsonVariantsStep(StepBuilderFactory stepBuilderFactory,
                                             SimpleCompletionPolicy chunkSizeCompletionPolicy) {
         return stepBuilderFactory.get(IMPORT_DBSNP_JSON_VARIANTS_STEP)
-                .<JsonNode, DbsnpClusteredVariantEntity>chunk(chunkSizeCompletionPolicy)
-                .reader(variantReader)
-                .processor(variantProcessor)
-                .build();
+            .<JsonNode, DbsnpClusteredVariantEntity>chunk(chunkSizeCompletionPolicy)
+            .reader(variantReader)
+            .processor(variantProcessor)
+            .writer(variantWriter)
+            .build();
     }
 }

--- a/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/configuration/ImportDbsnpJsonVariantsWriterConfiguration.java
+++ b/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/configuration/ImportDbsnpJsonVariantsWriterConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.dbsnp2.configuration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.data.MongoItemWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import uk.ac.ebi.eva.accession.core.persistence.DbsnpClusteredVariantEntity;
+
+import static uk.ac.ebi.eva.accession.dbsnp2.configuration.BeanNames.DBSNP_JSON_VARIANT_WRITER;
+
+@Configuration
+public class ImportDbsnpJsonVariantsWriterConfiguration {
+
+    private static final Logger logger = LoggerFactory.getLogger(ImportDbsnpJsonVariantsWriterConfiguration.class);
+
+    @Bean(name = DBSNP_JSON_VARIANT_WRITER)
+    @StepScope
+    public MongoItemWriter<DbsnpClusteredVariantEntity> writer(MongoTemplate mongoTemplate) {
+        MongoItemWriter<DbsnpClusteredVariantEntity> writer = new MongoItemWriter<>();
+        writer.setCollection("dbsnpClusteredVariantEntity");
+        writer.setTemplate(mongoTemplate);
+        return writer;
+    }
+}

--- a/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/parameters/InputParameters.java
+++ b/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/parameters/InputParameters.java
@@ -32,10 +32,10 @@ public class InputParameters {
 
     public JobParameters toJobParameters() {
         return new JobParametersBuilder()
-                .addString("input", input)
-                .addString("assembly", assembly)
-                .addLong("chunkSize", (long) chunkSize, false)
-                .toJobParameters();
+            .addString("input", input)
+            .addString("assembly", assembly)
+            .addLong("chunkSize", (long) chunkSize, false)
+            .toJobParameters();
     }
 
     public String getInput() {

--- a/eva-accession-import-dbsnp2/src/main/resources/application.properties
+++ b/eva-accession-import-dbsnp2/src/main/resources/application.properties
@@ -14,5 +14,6 @@ spring.data.mongodb.port=
 spring.data.mongodb.authentication-database=
 spring.data.mongodb.username=
 spring.data.mongodb.password=
+spring.data.mongodb.database=
 
 mongodb.read-preference=primaryPreferred

--- a/eva-accession-import-dbsnp2/src/test/java/uk/ac/ebi/eva/accession/dbsnp2/test/BatchTestConfiguration.java
+++ b/eva-accession-import-dbsnp2/src/test/java/uk/ac/ebi/eva/accession/dbsnp2/test/BatchTestConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import uk.ac.ebi.eva.accession.core.configuration.MongoConfiguration;
+import uk.ac.ebi.eva.accession.dbsnp2.configuration.ImportDbsnpJsonVariantsWriterConfiguration;
 import uk.ac.ebi.eva.accession.dbsnp2.configuration.ChunkSizeCompletionPolicyConfiguration;
 import uk.ac.ebi.eva.accession.dbsnp2.configuration.ImportDbsnpJsonVariantsJobConfiguration;
 import uk.ac.ebi.eva.accession.dbsnp2.configuration.JsonNodeToClusteredVariantProcessorConfiguration;
@@ -44,6 +45,7 @@ import uk.ac.ebi.eva.commons.batch.job.JobExecutionApplicationListener;
         ImportDbsnpJsonVariantsStepConfiguration.class,
         ImportDbsnpJsonVariantsReaderConfiguration.class,
         JsonNodeToClusteredVariantProcessorConfiguration.class,
+        ImportDbsnpJsonVariantsWriterConfiguration.class,
         ChunkSizeCompletionPolicyConfiguration.class,
         InputParametersConfiguration.class,
         ImportDbsnpJsonFlowConfiguration.class,


### PR DESCRIPTION

###Revision 1

- Writer implementation

####Test
Collection updates with 25 documents in it. Rerun of job results in same 25 documents in collection.
Sample document:
```
{
 "_id" : "13CB23F25B5A21C0D13B839F43A31CD50BD49414", 
"_class" : "uk.ac.ebi.eva.accession.core.persistence.DbsnpClusteredVariantEntity", 
"asm" : "GCF_000001405.38", 
"tax" : 9606, 
"contig" : "NC_000024.10", 
"start" : NumberLong(5793498), 
"type" : "MNV", 
"accession" : NumberLong(34072347), 
"version" : 1, 
"createdDate" : ISODate("2006-03-13T11:23:00Z") 
}
```